### PR TITLE
Corrected Experiment

### DIFF
--- a/src/main/java/dev/danvega/Application.java
+++ b/src/main/java/dev/danvega/Application.java
@@ -13,7 +13,6 @@ public class Application {
     private static final long BLOCKING_TIME_MS = 5; // Shorter sleep inside lock
     private static final int CPU_WORK_ITERATIONS = 10000; // Work *outside* lock
 
-    private static final Object lock = new Object();
     private static final AtomicInteger completedTasks = new AtomicInteger(0);
     private static volatile double busyWorkSink = 0; // To prevent dead code elimination
 
@@ -28,6 +27,8 @@ public class Application {
     }
 
     public static void main(String[] args) throws InterruptedException {
+        System.setProperty("jdk.virtualThreadScheduler.parallelism", "1");
+
         System.out.println("Running with Java version: " + System.getProperty("java.version"));
         System.out.printf("Launching %,d virtual threads...\n", NUM_THREADS);
         System.out.printf("Each thread does CPU work (%,d iterations), then acquires lock and blocks for %d ms.\n",
@@ -39,6 +40,7 @@ public class Application {
             Instant start = Instant.now();
 
             for (int i = 0; i < NUM_THREADS; i++) {
+                final Object lock = new Object();
                 executor.submit(() -> {
                     try {
                         // This work can run concurrently if carrier threads are available.


### PR DESCRIPTION
Hi! Thank you for your highlight. But it sounds like I found a mistake in your code.

Take another look at your synchronized block. It captures the monitor of the lock object. synchronized guarantees that the code inside the block will be executed by only one thread at a time, from start to finish.

Therefore, regardless of pinning, each Thread.sleep() is executed exclusively.

However, if you capture a different monitor each time (i.e., use a different lock object per task), you'll notice a significant difference — the performance can improve by an order of magnitude.

Please, look at my fixes there:
https://github.com/spring-aio/java24-pinning/blob/master/src/main/java/dev/danvega/Application.java#L43

I create new lock every time. So, for java 21, it works the same as in your code, due to carrier thread pinning (34.688 seconds for me). But for java 24 there is no pinning and the code is executed immediately (0.633 seconds for me).